### PR TITLE
Create gitlab build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,7 @@ pages:
   - ls -la
   - mkdir -p open-tacos 
   - ln -s $CI_PROJECT_DIR/content open-tacos/content
+  - ln -s $CI_PROJECT_DIR/public open-tacos/public
   - cd open-tacos && ls -la
   - git init .  && git remote add origin https://github.com/OpenBeta/open-tacos
   - git pull --depth=1 origin develop
@@ -35,7 +36,10 @@ pages:
 
   script:
   - ./node_modules/.bin/gatsby build
+  
+  after_script:
+  - mv build $CI_PROJECT_DIR
 
   artifacts:  # Use by GitLab pages
     paths:
-    - open-tacos/public
+    - public

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,39 @@
+cache:
+  paths:
+    - open-tacos/node_modules/
+    - open-tacos/.cache
+    - open-tacos/public
+
+image: node:16.3-buster-slim
+
+variables:
+  GIT_DEPTH: 1
+  DOCKER_DRIVER: overlay2
+
+# Job name must be 'pages' in order for GitLab to deploy to static site
+pages:
+  only: # Only run for these branches
+  - develop
+  - main
+  - gitlab-debug
+
+  stage: build
+
+  tags:
+  - docker
+
+  before_script:
+  - apt-get update && apt-get install -y git
+  - ls -ls
+  - mkdir -p open-tacos && cd open-tacos
+  - git init .  && git remote add origin https://github.com/OpenBeta/open-tacos
+  - git pull --depth=1 origin develop
+  - git checkout develop
+  - yarn install --no-progress
+
+  script:
+  - ./node_modules/.bin/gatsby build
+
+  artifacts:  # Use by GitLab pages
+    paths:
+    - opentacos/public

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,4 +37,4 @@ pages:
 
   artifacts:  # Use by GitLab pages
     paths:
-    - opentacos/public
+    - open-tacos/public

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,7 @@ pages:
   - git pull --depth=1 origin develop
   - git checkout develop
   - yarn install --no-progress
+  - ln -s $CI_PROJECT_DIR content
 
   script:
   - ./node_modules/.bin/gatsby build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ pages:
   - apt-get update && apt-get install -y git
   - ls -la
   - mkdir -p open-tacos 
-  - ln -s $CI_PROJECT_DIR open-tacos/content
+  - ln -s $CI_PROJECT_DIR/content open-tacos/content
   - cd open-tacos && ls -la
   - git init .  && git remote add origin https://github.com/OpenBeta/open-tacos
   - git pull --depth=1 origin develop

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,12 +25,13 @@ pages:
   before_script:
   - apt-get update && apt-get install -y git
   - ls -la
-  - mkdir -p open-tacos && cd open-tacos && ls -la
+  - mkdir -p open-tacos 
+  - ln -s $CI_PROJECT_DIR open-tacos/content
+  - cd open-tacos && ls -la
   - git init .  && git remote add origin https://github.com/OpenBeta/open-tacos
   - git pull --depth=1 origin develop
   - git checkout develop
   - yarn install --no-progress
-  - ln -s $CI_PROJECT_DIR open-tacos/content
 
   script:
   - ./node_modules/.bin/gatsby build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ cache:
   paths:
     - open-tacos/node_modules/
     - open-tacos/.cache
-    - open-tacos/public
+    - public
 
 image: node:16.3-buster-slim
 
@@ -26,7 +26,6 @@ pages:
   - apt-get update && apt-get install -y git
   - mkdir -p open-tacos 
   - ln -s $CI_PROJECT_DIR/content open-tacos/content
-  - ln -s $CI_PROJECT_DIR/open-tacos/public public
   - cd open-tacos && ls -la
   - git init .  && git remote add origin https://github.com/OpenBeta/open-tacos
   - git pull --depth=1 origin develop
@@ -35,6 +34,7 @@ pages:
 
   script:
   - ./node_modules/.bin/gatsby build
+  - mv public $CI_PROJECT_DIR
 
   artifacts:  # Use by GitLab pages
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,8 +26,8 @@ pages:
   - apt-get update && apt-get install -y git
   - ls -la
   - mkdir -p open-tacos 
-  - ln -s $CI_PROJECT_DIR/content open-tacos/content
-  - ln -s $CI_PROJECT_DIR/public open-tacos/public
+  - ln -s content open-tacos/content
+  - ln -s open-tacos/public public
   - cd open-tacos && ls -la
   - git init .  && git remote add origin https://github.com/OpenBeta/open-tacos
   - git pull --depth=1 origin develop
@@ -36,9 +36,6 @@ pages:
 
   script:
   - ./node_modules/.bin/gatsby build
-  
-  after_script:
-  - mv build $CI_PROJECT_DIR
 
   artifacts:  # Use by GitLab pages
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
   GIT_DEPTH: 1
   DOCKER_DRIVER: overlay2
 
-# Job name must be 'pages' in order for GitLab to deploy to static site
+# Job name must be 'pages' in order for GitLab to deploy build to static site
 pages:
   only: # Only run for these branches
   - develop
@@ -24,10 +24,9 @@ pages:
 
   before_script:
   - apt-get update && apt-get install -y git
-  - ls -la
   - mkdir -p open-tacos 
-  - ln -s content open-tacos/content
-  - ln -s open-tacos/public public
+  - ln -s $CI_PROJECT_DIR/content open-tacos/content
+  - ln -s $CI_PROJECT_DIR/open-tacos/public public
   - cd open-tacos && ls -la
   - git init .  && git remote add origin https://github.com/OpenBeta/open-tacos
   - git pull --depth=1 origin develop

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,8 +24,8 @@ pages:
 
   before_script:
   - apt-get update && apt-get install -y git
-  - ls -ls
-  - mkdir -p open-tacos && cd open-tacos
+  - ls -la
+  - mkdir -p open-tacos && cd open-tacos && ls -la
   - git init .  && git remote add origin https://github.com/OpenBeta/open-tacos
   - git pull --depth=1 origin develop
   - git checkout develop

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ pages:
   - git pull --depth=1 origin develop
   - git checkout develop
   - yarn install --no-progress
-  - ln -s $CI_PROJECT_DIR content
+  - ln -s $CI_PROJECT_DIR open-tacos/content
 
   script:
   - ./node_modules/.bin/gatsby build


### PR DESCRIPTION
Create a new CI pipeline in GitLab independent of the code repo's (open-tacos).  This allows us to update content and push code at a different cadence.  We can also add GitHub actions to help area admins to verify user edits.