### PR TITLE
Move files instead of symlink

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,8 @@ pages:
   before_script:
   - apt-get update && apt-get install -y git
   - mkdir -p open-tacos 
-  - ln -s $CI_PROJECT_DIR/content open-tacos/content
+  - mv content open-tacos
+  # we need to move build output dir to top level for GitLab pages to work
   - '[ -d public ] && mv public open-tacos'
   - cd open-tacos && ls -la
   - git init .  && git remote add origin https://github.com/OpenBeta/open-tacos


### PR DESCRIPTION
Update build script to use move files instead creating symlink which has been source of the strange null byte in path error.
```
Error: TypeError [ERR_INVALID_ARG_VALUE]: The argument 'path' must be a string   
or Uint8Array without null bytes. 
Received '/builds/B2goyrEA/0/openbeta/opentacos-content-ci/open-tacos/\x00/builds/B2goyrEA/0/openbeta/opentacos-content-c  i/open-tacos/con...
```