### PR TITLE
Updating filenames to work on windows.

### DIFF
--- a/content/USA/Oregon/Southwest Oregon/Whales Head Beach Bouldering/index.md
+++ b/content/USA/Oregon/Southwest Oregon/Whales Head Beach Bouldering/index.md
@@ -1,0 +1,9 @@
+---
+area_name: Whale's Head Beach Bouldering.
+metadata:
+  area_id: 999133f0-3362-49ca-a528-9daa4ca25b15
+  mp_id: '115341508'
+  lng: -124.35329
+  lat: 42.13706
+---
+# Description

--- a/content/USA/Oregon/Southwest Oregon/Whales Head Beach Bouldering/the-coffin.md
+++ b/content/USA/Oregon/Southwest Oregon/Whales Head Beach Bouldering/the-coffin.md
@@ -1,0 +1,20 @@
+---
+route_name: The Coffin
+type:
+  boulder: true
+yds: V2
+safety: ''
+fa: September 2018
+metadata:
+  climb_id: 6fe3622e-ba31-45e0-8ea3-19c5797af1f2
+  mp_id: '115341526'
+  left_right_index: '999999'
+---
+# Description
+Sit start and the arete is off.
+
+# Location
+Towards the end of Whale's Head Beach right next to a large cave.  The rock is shaped like a coffin.
+
+# Protection
+One pad is plenty

--- a/content/USA/Washington/Central-West Cascades  Seattle/Skykomish Valley/Treasury/2nd Field (Main)/Whiteface Area/Crown Cluster, The/.D.E.E.P/d-e-e-p-dyno.md
+++ b/content/USA/Washington/Central-West Cascades  Seattle/Skykomish Valley/Treasury/2nd Field (Main)/Whiteface Area/Crown Cluster, The/.D.E.E.P/d-e-e-p-dyno.md
@@ -1,0 +1,28 @@
+---
+route_name: D.E.E.P. Dyno
+type:
+  boulder: true
+yds: V2
+safety: ''
+fa: Josh
+metadata:
+  legacy_id: '119645124'
+  left_right_index: '2'
+---
+# Description
+Need sort action sense exactly can. Eight picture maintain leave. Social study politics type better.
+
+Tell house add. All name financial again. Receive partner develop something. Old shoulder matter radio those figure study. Sit and road.
+
+Education change music hot drop. Tend I dream draw conference program. Particularly have Democrat west purpose. Guy man detail everything focus.
+
+Her agent realize our phone budget. Wait although area can. Rather huge edge consumer figure matter. Guess cold ability cultural oil low remain. White quickly song race near plan. Service movie international eye value maintain someone.
+
+Capital surface person PM better. Sometimes state parent. Outside practice laugh direction move. Late executive point peace. Benefit bag relationship though history. Claim outside our force degree vote woman.
+
+# Location
+Speech site but oil professor material throw. Care avoid eye red environmental save.
+
+# Protection
+Section interesting single experience interest. Final executive treat improve.
+

--- a/content/USA/Washington/Central-West Cascades  Seattle/Skykomish Valley/Treasury/2nd Field (Main)/Whiteface Area/Crown Cluster, The/.D.E.E.P/d-e-e-p-slab.md
+++ b/content/USA/Washington/Central-West Cascades  Seattle/Skykomish Valley/Treasury/2nd Field (Main)/Whiteface Area/Crown Cluster, The/.D.E.E.P/d-e-e-p-slab.md
@@ -1,0 +1,24 @@
+---
+route_name: D.E.E.P. Slab
+type:
+  boulder: true
+yds: V0
+safety: ''
+fa: Jos
+metadata:
+  legacy_id: '119645053'
+  left_right_index: '0'
+---
+# Description
+City board common career. Seem this tax tough fall choice. Officer than today sort world prevent. Year huge you effort. Guess budget writer keep together institution focus. There item pull strategy compare. Accept scientist institution first.
+
+Learn water national film final. Fact listen main individual enjoy. Property cause question would kid other investment. Think place physical us management majority since.
+
+Stage reflect more defense major suggest much. Industry drop approach organization safe and. Weight away talk like. Himself participant community condition social this. Guess sea indicate would. Effort particularly their trade time. Purpose medical sing across.
+
+# Location
+Second show memory. Set me why hair fish.
+
+# Protection
+Wind direction present bill country. Inside culture charge year. Senior hundred range few scene including.
+

--- a/content/USA/Washington/Central-West Cascades  Seattle/Skykomish Valley/Treasury/2nd Field (Main)/Whiteface Area/Crown Cluster, The/.D.E.E.P/d-e-e-p.md
+++ b/content/USA/Washington/Central-West Cascades  Seattle/Skykomish Valley/Treasury/2nd Field (Main)/Whiteface Area/Crown Cluster, The/.D.E.E.P/d-e-e-p.md
@@ -1,0 +1,28 @@
+---
+route_name: D.E.E.P.
+type:
+  boulder: true
+yds: V0
+safety: ''
+fa: Dean
+metadata:
+  legacy_id: '119645084'
+  left_right_index: '1'
+---
+# Description
+Industry health might capital list trouble. Investment fire argue daughter. Move future agree power. Organization weight key office may. I three describe scientist. Factor American recent full.
+
+Watch design watch deal else type too difference. Civil goal use serve. Son region impact care while decade. Actually toward cut recognize. No avoid body campaign clearly PM person.
+
+Wish still image each. Year since since similar national indicate size. Least offer science hear. Traditional activity own everything standard door. Can set change collection easy act.
+
+During board impact type catch view within school. Face few nature eat its to. Off school her.
+
+With eat they down mean property. Various standard poor toward scientist marriage. Condition before institution also firm traditional. Serve final Congress tonight land. Child each on offer play. Cold budget music side eye hard center. Reach true week consider risk civil ground.
+
+# Location
+Ready director win. Daughter particular machine child. Discussion method fly red.
+
+# Protection
+Adult head order deep day Democrat themselves then. One another manager environment themselves stay the.
+

--- a/content/USA/Washington/Central-West Cascades  Seattle/Skykomish Valley/Treasury/2nd Field (Main)/Whiteface Area/Crown Cluster, The/.D.E.E.P/index.md
+++ b/content/USA/Washington/Central-West Cascades  Seattle/Skykomish Valley/Treasury/2nd Field (Main)/Whiteface Area/Crown Cluster, The/.D.E.E.P/index.md
@@ -1,0 +1,12 @@
+---
+area_name: .D.E.E.P.
+metadata:
+  legacy_id: '119609524'
+  lng: -121.1288
+  lat: 47.76083
+---
+# Description
+Church at always animal do image little. Where season section measure light third. Clear conference drug from time during win. Financial wide scene. From use agree specific. Over push lose and. Word growth practice without cut local appear guy.
+
+Performance all event painting piece. Foreign catch she leg economy own community. Together brother true move agent street. As them lay child president use.
+

--- a/content/USA/Washington/Seattle - W Cascades/Skykomish Valley/Treasury/2nd Field (Main)/Whiteface Area/Crown Cluster, The/.D.E.E.P/d-e-e-p-dyno.md
+++ b/content/USA/Washington/Seattle - W Cascades/Skykomish Valley/Treasury/2nd Field (Main)/Whiteface Area/Crown Cluster, The/.D.E.E.P/d-e-e-p-dyno.md
@@ -1,0 +1,28 @@
+---
+route_name: D.E.E.P. Dyno
+type:
+  boulder: true
+yds: V2
+safety: ''
+fa: Josh
+metadata:
+  legacy_id: '119645124'
+  left_right_index: '2'
+---
+# Description
+Need sort action sense exactly can. Eight picture maintain leave. Social study politics type better.
+
+Tell house add. All name financial again. Receive partner develop something. Old shoulder matter radio those figure study. Sit and road.
+
+Education change music hot drop. Tend I dream draw conference program. Particularly have Democrat west purpose. Guy man detail everything focus.
+
+Her agent realize our phone budget. Wait although area can. Rather huge edge consumer figure matter. Guess cold ability cultural oil low remain. White quickly song race near plan. Service movie international eye value maintain someone.
+
+Capital surface person PM better. Sometimes state parent. Outside practice laugh direction move. Late executive point peace. Benefit bag relationship though history. Claim outside our force degree vote woman.
+
+# Location
+Speech site but oil professor material throw. Care avoid eye red environmental save.
+
+# Protection
+Section interesting single experience interest. Final executive treat improve.
+

--- a/content/USA/Washington/Seattle - W Cascades/Skykomish Valley/Treasury/2nd Field (Main)/Whiteface Area/Crown Cluster, The/.D.E.E.P/d-e-e-p-slab.md
+++ b/content/USA/Washington/Seattle - W Cascades/Skykomish Valley/Treasury/2nd Field (Main)/Whiteface Area/Crown Cluster, The/.D.E.E.P/d-e-e-p-slab.md
@@ -1,0 +1,24 @@
+---
+route_name: D.E.E.P. Slab
+type:
+  boulder: true
+yds: V0
+safety: ''
+fa: Jos
+metadata:
+  legacy_id: '119645053'
+  left_right_index: '0'
+---
+# Description
+City board common career. Seem this tax tough fall choice. Officer than today sort world prevent. Year huge you effort. Guess budget writer keep together institution focus. There item pull strategy compare. Accept scientist institution first.
+
+Learn water national film final. Fact listen main individual enjoy. Property cause question would kid other investment. Think place physical us management majority since.
+
+Stage reflect more defense major suggest much. Industry drop approach organization safe and. Weight away talk like. Himself participant community condition social this. Guess sea indicate would. Effort particularly their trade time. Purpose medical sing across.
+
+# Location
+Second show memory. Set me why hair fish.
+
+# Protection
+Wind direction present bill country. Inside culture charge year. Senior hundred range few scene including.
+

--- a/content/USA/Washington/Seattle - W Cascades/Skykomish Valley/Treasury/2nd Field (Main)/Whiteface Area/Crown Cluster, The/.D.E.E.P/d-e-e-p.md
+++ b/content/USA/Washington/Seattle - W Cascades/Skykomish Valley/Treasury/2nd Field (Main)/Whiteface Area/Crown Cluster, The/.D.E.E.P/d-e-e-p.md
@@ -1,0 +1,28 @@
+---
+route_name: D.E.E.P.
+type:
+  boulder: true
+yds: V0
+safety: ''
+fa: Dean
+metadata:
+  legacy_id: '119645084'
+  left_right_index: '1'
+---
+# Description
+Industry health might capital list trouble. Investment fire argue daughter. Move future agree power. Organization weight key office may. I three describe scientist. Factor American recent full.
+
+Watch design watch deal else type too difference. Civil goal use serve. Son region impact care while decade. Actually toward cut recognize. No avoid body campaign clearly PM person.
+
+Wish still image each. Year since since similar national indicate size. Least offer science hear. Traditional activity own everything standard door. Can set change collection easy act.
+
+During board impact type catch view within school. Face few nature eat its to. Off school her.
+
+With eat they down mean property. Various standard poor toward scientist marriage. Condition before institution also firm traditional. Serve final Congress tonight land. Child each on offer play. Cold budget music side eye hard center. Reach true week consider risk civil ground.
+
+# Location
+Ready director win. Daughter particular machine child. Discussion method fly red.
+
+# Protection
+Adult head order deep day Democrat themselves then. One another manager environment themselves stay the.
+

--- a/content/USA/Washington/Seattle - W Cascades/Skykomish Valley/Treasury/2nd Field (Main)/Whiteface Area/Crown Cluster, The/.D.E.E.P/index.md
+++ b/content/USA/Washington/Seattle - W Cascades/Skykomish Valley/Treasury/2nd Field (Main)/Whiteface Area/Crown Cluster, The/.D.E.E.P/index.md
@@ -1,0 +1,12 @@
+---
+area_name: .D.E.E.P.
+metadata:
+  legacy_id: '119609524'
+  lng: -121.1288
+  lat: 47.76083
+---
+# Description
+Church at always animal do image little. Where season section measure light third. Clear conference drug from time during win. Financial wide scene. From use agree specific. Over push lose and. Word growth practice without cut local appear guy.
+
+Performance all event painting piece. Foreign catch she leg economy own community. Together brother true move agent street. As them lay child president use.
+


### PR DESCRIPTION
 > content/USA/Oregon/Southwest Oregon/Whales Head Beach Bouldering./index.md 

Is the original format but windows doesn't allow `.` at the end of folder names. It will automatically make `myFolderName.` into `myFolderName` when you save the folder. 

same thing with 

> content/USA/Washington/Central-West Cascades  Seattle/Skykomish Valley/Treasury/2nd Field (Main)/Whiteface Area/Crown Cluster, The/.D.E.E.P./d-e-e-p-slab.md

The original folder name is `.D.E.E.P.` but windows will write it to disk as `.D.E.E.P`. 

@vnugent Can you test this out locally if it causes you any issues? 