### PR TITLE
#91 Markdown Linter & Lint Fixes

### DIFF
--- a/.github/linter.yml
+++ b/.github/linter.yml
@@ -1,0 +1,56 @@
+---
+#################################
+#################################
+## Super Linter GitHub Actions ##
+#################################
+#################################
+name: Lint Code Base
+
+#
+# Documentation:
+# https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+#
+
+#############################
+# Start the job on all push #
+#############################
+on:
+  push:
+    branches-ignore: [master, main]
+    # Remove the line above to run when pushing to master
+  pull_request:
+    branches: [master, main]
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    # Name the Job
+    name: Lint Code Base
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    ##################
+    # Load all steps #
+    ##################
+    steps:
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_MARKDOWN: true
+          DEFAULT_BRANCH: develop
+          MARKDOWN_CONFIG_FILE: ".markdownlint.yml"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,7 +19,7 @@ on:
     branches-ignore: [main]
     # Remove the line above to run when pushing to master
   pull_request:
-    branches: [ main, develop]
+    branches: [main, develop]
 
 ###############
 # Set the Job #
@@ -50,7 +50,9 @@ jobs:
       - name: Lint Code Base
         uses: github/super-linter@v4
         env:
+          VALIDATE_ALL_CODEBASE: false
           VALIDATE_MARKDOWN: true
           DEFAULT_BRANCH: develop
-          MARKDOWN_CONFIG_FILE: ".markdownlint.yml"
+          LINTER_RULES_PATH: /
+          MARKDOWN_CONFIG_FILE: '.markdownlint.yml'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,10 +16,10 @@ name: Lint Code Base
 #############################
 on:
   push:
-    branches-ignore: [master, main]
+    branches-ignore: [main]
     # Remove the line above to run when pushing to master
   pull_request:
-    branches: [master, main]
+    branches: [ main, develop]
 
 ###############
 # Set the Job #

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,220 @@
+# Example markdownlint YAML configuration with all properties set to their default value
+
+# Default state for all rules
+default: true
+
+# Path to configuration file to extend
+extends: null
+
+# MD001/heading-increment/header-increment - Heading levels should only increment by one level at a time
+MD001: true
+
+# MD002/first-heading-h1/first-header-h1 - First heading should be a top-level heading
+MD002:
+  # Heading level
+  level: 1
+
+# MD003/heading-style/header-style - Heading style
+MD003:
+  # Heading style
+  style: "consistent"
+
+# MD004/ul-style - Unordered list style
+MD004:
+  # List style
+  style: "consistent"
+
+# MD005/list-indent - Inconsistent indentation for list items at the same level
+MD005: true
+
+# MD006/ul-start-left - Consider starting bulleted lists at the beginning of the line
+MD006: true
+
+# MD007/ul-indent - Unordered list indentation
+MD007:
+  # Spaces for indent
+  indent: 2
+  # Whether to indent the first level of the list
+  start_indented: false
+
+# MD009/no-trailing-spaces - Trailing spaces
+MD009:
+  # Spaces for line break
+  br_spaces: 2
+  # Allow spaces for empty lines in list items
+  list_item_empty_lines: false
+  # Include unnecessary breaks
+  strict: false
+
+# MD010/no-hard-tabs - Hard tabs
+MD010:
+  # Include code blocks
+  code_blocks: true
+  # Number of spaces for each hard tab
+  spaces_per_tab: 1
+
+# MD011/no-reversed-links - Reversed link syntax
+MD011: true
+
+# MD012/no-multiple-blanks - Multiple consecutive blank lines
+MD012:
+  # Consecutive blank lines
+  maximum: 2
+
+# MD013/line-length - Line length
+MD013:
+  # Number of characters
+  line_length: 3000
+  # Number of characters for headings
+  heading_line_length: 80
+  # Number of characters for code blocks
+  code_block_line_length: 80
+  # Include code blocks
+  code_blocks: true
+  # Include tables
+  tables: true
+  # Include headings
+  headings: true
+  # Include headings
+  headers: true
+  # Strict length checking
+  strict: false
+  # Stern length checking
+  stern: false
+
+# MD014/commands-show-output - Dollar signs used before commands without showing output
+MD014: true
+
+# MD018/no-missing-space-atx - No space after hash on atx style heading
+MD018: true
+
+# MD019/no-multiple-space-atx - Multiple spaces after hash on atx style heading
+MD019: true
+
+# MD020/no-missing-space-closed-atx - No space inside hashes on closed atx style heading
+MD020: true
+
+# MD021/no-multiple-space-closed-atx - Multiple spaces inside hashes on closed atx style heading
+MD021: true
+
+# MD022/blanks-around-headings/blanks-around-headers - Headings should be surrounded by blank lines
+MD022:
+  false
+  # Blank lines above heading
+  #lines_above: 1
+  # Blank lines below heading
+  #lines_below: 1
+
+# MD023/heading-start-left/header-start-left - Headings must start at the beginning of the line
+MD023: true
+
+# MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
+MD024:
+  # Only check sibling headings
+  allow_different_nesting: false
+  # Only check sibling headings
+  siblings_only: false
+
+# MD025/single-title/single-h1 - Multiple top-level headings in the same document
+MD025: false # Current structure doesn't match
+
+# MD026/no-trailing-punctuation - Trailing punctuation in heading
+MD026:
+  # Punctuation characters
+  punctuation: ".,;:!。，；：！"
+
+# MD027/no-multiple-space-blockquote - Multiple spaces after blockquote symbol
+MD027: true
+
+# MD028/no-blanks-blockquote - Blank line inside blockquote
+MD028: true
+
+# MD029/ol-prefix - Ordered list item prefix
+MD029:
+  # List style
+  style: "one_or_ordered"
+
+# MD030/list-marker-space - Spaces after list markers
+MD030:
+  # Spaces for single-line unordered list items
+  ul_single: 1
+  # Spaces for single-line ordered list items
+  ol_single: 1
+  # Spaces for multi-line unordered list items
+  ul_multi: 1
+  # Spaces for multi-line ordered list items
+  ol_multi: 1
+
+# MD031/blanks-around-fences - Fenced code blocks should be surrounded by blank lines
+MD031:
+  # Include list items
+  list_items: true
+
+# MD032/blanks-around-lists - Lists should be surrounded by blank lines
+MD032: true
+
+# MD033/no-inline-html - Inline HTML
+MD033:
+  # Allowed elements
+  allowed_elements: []
+
+# MD034/no-bare-urls - Bare URL used
+MD034: true
+
+# MD035/hr-style - Horizontal rule style
+MD035:
+  # Horizontal rule style
+  style: "consistent"
+
+# MD036/no-emphasis-as-heading/no-emphasis-as-header - Emphasis used instead of a heading
+MD036:
+  # Punctuation characters
+  punctuation: ".,;:!?。，；：！？"
+
+# MD037/no-space-in-emphasis - Spaces inside emphasis markers
+MD037: true
+
+# MD038/no-space-in-code - Spaces inside code span elements
+MD038: true
+
+# MD039/no-space-in-links - Spaces inside link text
+MD039: true
+
+# MD040/fenced-code-language - Fenced code blocks should have a language specified
+MD040: true
+
+# MD041/first-line-heading/first-line-h1 - First line in a file should be a top-level heading
+MD041:
+  # Heading level
+  level: 1
+  # RegExp for matching title in front matter
+  front_matter_title: "^\\s*title\\s*[:=]"
+
+# MD042/no-empty-links - No empty links
+MD042: true
+
+# MD043/required-headings/required-headers - Required heading structure
+MD043: false # Optional to require description
+
+# MD044/proper-names - Proper names should have the correct capitalization
+MD044:
+  # List of proper names
+  names: []
+  # Include code blocks
+  code_blocks: true
+
+# MD045/no-alt-text - Images should have alternate text (alt text)
+MD045: true
+
+# MD046/code-block-style - Code block style
+MD046:
+  # Block style
+  style: "consistent"
+
+# MD047/single-trailing-newline - Files should end with a single newline character
+MD047: false
+
+# MD048/code-fence-style - Code fence style
+MD048:
+  # Code fence style
+  style: "consistent"

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "trailingComma": "es5",
+    "tabWidth": 2,
+    "semi": false,
+    "singleQuote": true
+}

--- a/content/USA/Oregon/Central Oregon/Meadow Camp/awesome-arete.md
+++ b/content/USA/Oregon/Central Oregon/Meadow Camp/awesome-arete.md
@@ -10,19 +10,21 @@ metadata:
   mp_id: '111649838'
   left_right_index: '36'
 ---
+
 # Description
+
 Definitely one of the best face routes at Meadow Camp. Start on slightly overhanging face holds just a few feet right of the start for "Solstice" and work up to an interesting traverse right and up to a big ledge.
 
 From the ledge you have two choices:
 
-1) move left and make a difficult balance move left around the arete, and continue up the left side reaching back around right when you get to the obvious pockets. With your right hand in the pockets, make a hard pull to a small pinch on the arete, then gain the top! (11d/12a) (Note: you do have to contrive slightly to keep yourself from reaching all the way over to the right edge when you gain the pockets, but otherwise this really is a pretty natural line)
+1. move left and make a difficult balance move left around the arete, and continue up the left side reaching back around right when you get to the obvious pockets. With your right hand in the pockets, make a hard pull to a small pinch on the arete, then gain the top! (11d/12a) (Note: you do have to contrive slightly to keep yourself from reaching all the way over to the right edge when you gain the pockets, but otherwise this really is a pretty natural line)
 
-Or:
-
-2) Stay on the right side of the arete, moving up with one hand on each side of the pillar, utilizing heel hooks on both sides. (10d/11a) (this way also feels a little contrived since you aren't fully entering the crack on the right)
+2. Stay on the right side of the arete, moving up with one hand on each side of the pillar, utilizing heel hooks on both sides. (10d/11a) (this way also feels a little contrived since you aren't fully entering the crack on the right)
 
 # Location
+
 The striking arete just to the right of "Solstice."
 
 # Protection
+
 Single eye bolt, easily backed up with the anchor for "Solstice" 3' away.

--- a/content/USA/Oregon/Central Oregon/Smith Rock/Lower Gorge/East Side/So Lo Wall/pipsqueak.md
+++ b/content/USA/Oregon/Central Oregon/Smith Rock/Lower Gorge/East Side/So Lo Wall/pipsqueak.md
@@ -2,19 +2,23 @@
 route_name: Pipsqueak
 type:
   trad: true
-yds: '5.8'
-safety: ''
+yds: "5.8"
+safety: ""
 fa: unknown to me
 metadata:
   climb_id: 2c91f183-3245-4e9c-baba-04294dbecb15
-  mp_id: '107166412'
-  left_right_index: '2'
+  mp_id: "107166412"
+  left_right_index: "2"
 ---
+
 # Description
+
 This is the best looking and most distinctive line on the wall. Although it's quite short, it is a nice climb and might make a good, gentle introduction to steeper crack climbing.
 
 # Location
+
 This is towards the left side of the wall. Locate a very small roof low to the ground. This climbs the hand crack on the right side of the roof. After surmounting the hand crack trend up and right to a bolted rappel anchor.
 
 # Protection
-#2 Camalots. A #3 Camalot could be finagled in higher in the crack. Fixed rappel anchors.
+
+\#2 Camalots. A #3 Camalot could be finagled in higher in the crack. Fixed rappel anchors

--- a/content/USA/Oregon/Central Oregon/Smith Rock/Monkey Face/moving-in-stereo.md
+++ b/content/USA/Oregon/Central Oregon/Smith Rock/Monkey Face/moving-in-stereo.md
@@ -19,7 +19,7 @@ The crux felt hard for the grade, definitely old school 11d. Felt like 12a to me
 
 You could TR off the first anchor, but a better ledge awaits you 50 ft higher if you're continuing up Astro Monkey. Its 5.8ish to the next belay, and some sketch rock, so you may want a .5 or .75 piece, and you should probably bring a piece to back up the belay. There is one good bolt, but the other two are questionable:
 
-https://www.mountainproject.com/photo/111123032
+<https://www.mountainproject.com/photo/111123032>
 
 # Location
 Astro Monkey is left by about 15 feet, and has 3 bolts below a tips crack. Moving in Stereo is solidly bolted the whole way. Both routes start literally right off the trail below the west face of the Monkey Face.

--- a/content/USA/Oregon/Central Oregon/Smith Rock/Smith Rock Bouldering/Main Smith Rock Area/charlotte-s-web-right.md
+++ b/content/USA/Oregon/Central Oregon/Smith Rock/Smith Rock Bouldering/Main Smith Rock Area/charlotte-s-web-right.md
@@ -21,7 +21,7 @@ Charlotte's Web
 
 . Top out rightward around the boulder.
 
-https://www.youtube.com/watch?v=a7pnqu9hQVk&list=PLjJ8XYZXIxuLQd7DJOGNlv9CHPnXc0B_0&index=11
+<https://www.youtube.com/watch?v=a7pnqu9hQVk&list=PLjJ8XYZXIxuLQd7DJOGNlv9CHPnXc0B_0&index=11>
 
 # Location
 (Disclaimer: I'm pulling these directions from memory, so they may be a bit off)

--- a/content/USA/Oregon/Central Oregon/Smith Rock/Smith Rock Bouldering/Main Smith Rock Area/charlotte-s-web.md
+++ b/content/USA/Oregon/Central Oregon/Smith Rock/Smith Rock Bouldering/Main Smith Rock Area/charlotte-s-web.md
@@ -13,7 +13,7 @@ metadata:
 # Description
 Start matched in the hueco or start left in the hueco and right in the multi-finger pocket on the opposing face. Follow a few pockets straight up to an overhead press and eventual top out. Watch out for spiders!
 
-https://www.youtube.com/watch?v=dIb_-Hgs-8A&list=PLjJ8XYZXIxuLQd7DJOGNlv9CHPnXc0B_0&index=1
+<https://www.youtube.com/watch?v=dIb_-Hgs-8A&list=PLjJ8XYZXIxuLQd7DJOGNlv9CHPnXc0B_0&index=1>
 
 # Location
 (Disclaimer: I'm pulling these directions from memory, so they may be a bit off)

--- a/content/USA/Oregon/Central Oregon/Smith Rock/Smith Rock Bouldering/Main Smith Rock Area/strawberry-sorbet.md
+++ b/content/USA/Oregon/Central Oregon/Smith Rock/Smith Rock Bouldering/Main Smith Rock Area/strawberry-sorbet.md
@@ -13,7 +13,7 @@ metadata:
 # Description
 Start low on a left sidepull and right pinch. Move up to a crimp with your right and bump your left up to one of the many good holds. Make a heel assisted reachy move around the right of the boulder and top out a little off to the right.
 
-https://www.youtube.com/watch?v=f-YIc1Ln_9g&list=PLjJ8XYZXIxuLQd7DJOGNlv9CHPnXc0B_0&index=10
+<https://www.youtube.com/watch?v=f-YIc1Ln_9g&list=PLjJ8XYZXIxuLQd7DJOGNlv9CHPnXc0B_0&index=10>
 
 # Location
 (Disclaimer: I'm pulling these directions from memory, so they may be a bit off)

--- a/content/USA/Oregon/Central Oregon/Smith Rock/Smith Rock Bouldering/Main Smith Rock Area/templeton.md
+++ b/content/USA/Oregon/Central Oregon/Smith Rock/Smith Rock Bouldering/Main Smith Rock Area/templeton.md
@@ -13,7 +13,7 @@ metadata:
 # Description
 Solid warmup along Charlotte Web's right arete.
 
-https://www.youtube.com/watch?v=MemL3i9XD-w&list=PLjJ8XYZXIxuLQd7DJOGNlv9CHPnXc0B_0&index=7
+<https://www.youtube.com/watch?v=MemL3i9XD-w&list=PLjJ8XYZXIxuLQd7DJOGNlv9CHPnXc0B_0&index=7>
 
 # Location
 (Disclaimer: I'm pulling these directions from memory, so they may be a bit off)

--- a/content/USA/Oregon/Central Oregon/Smith Rock/Smith Rock Bouldering/Main Smith Rock Area/wilbur.md
+++ b/content/USA/Oregon/Central Oregon/Smith Rock/Smith Rock Bouldering/Main Smith Rock Area/wilbur.md
@@ -13,7 +13,7 @@ metadata:
 # Description
 Start on the sidepull (left) and hueco (right) or matched in the hueco. Move up to a tricky match inside of a good hueco. Top out up and left.
 
-https://www.youtube.com/watch?v=7ULHnstMjPs&list=PLjJ8XYZXIxuLQd7DJOGNlv9CHPnXc0B_0&index=12
+<https://www.youtube.com/watch?v=7ULHnstMjPs&list=PLjJ8XYZXIxuLQd7DJOGNlv9CHPnXc0B_0&index=12>
 
 # Location
 (Disclaimer: I'm pulling these directions from memory, so they may be a bit off)

--- a/content/USA/Oregon/Central Oregon/Smith Rock/Smith Rock Group/Northeast Face/season-s-change.md
+++ b/content/USA/Oregon/Central Oregon/Smith Rock/Smith Rock Group/Northeast Face/season-s-change.md
@@ -10,45 +10,51 @@ metadata:
   mp_id: '106679458'
   left_right_index: '7'
 ---
-# Description
-Season's Change is six pitches of exposed climbing on one of the least visited sections of Smith Rock.  Expect long pitches of pebbling, with shiny new bolts everywhere, and only occasional run-outs.
 
-As of now (early 2010), the route still suffers from poor rock.  On the bright side, some sections of Smith feel as though they will never be clean, but this isn't one of them.  With a dozen more ascents (or one ascent specifically for cleaning), this route will likely be solid, and completely amazing.  Bring helmets, call "rock", and be comforted by the fact that almost all pitches wander a bit away from the belay.  The first pitch may never be very good, but the rest should clean up nicely.
+# Description
+
+Season's Change is six pitches of exposed climbing on one of the least visited sections of Smith Rock. Expect long pitches of pebbling, with shiny new bolts everywhere, and only occasional run-outs.
+
+As of now (early 2010), the route still suffers from poor rock. On the bright side, some sections of Smith feel as though they will never be clean, but this isn't one of them. With a dozen more ascents (or one ascent specifically for cleaning), this route will likely be solid, and completely amazing. Bring helmets, call "rock", and be comforted by the fact that almost all pitches wander a bit away from the belay. The first pitch may never be very good, but the rest should clean up nicely.
 
 It was a mistake to climb this route in the winter without adequate clothing, but that was not clear until we were high on the wind-whipped wall and psychologically committed to finishing. Retreat was physically possible, but unthinkable.
 
-For us, Season's Change was a formidable route, and worth the time.  In better conditions, it may have been enjoyable, but the brutal conditions, and the necessity of rising to the boldness of the route were more than adequate substitutes for joy.  A great adventure sport route, with the safety of modern hardware.
+For us, Season's Change was a formidable route, and worth the time. In better conditions, it may have been enjoyable, but the brutal conditions, and the necessity of rising to the boldness of the route were more than adequate substitutes for joy. A great adventure sport route, with the safety of modern hardware.
 
 All bolt numbers are approximate - bring extra draws and a runner or two.
 
-Pitch 1 (10a): 7 bolts.  Make your way over a couple of big lumps, clip at 20 feet, and then execute a miserable traverse.
+Pitch 1 (10a): 7 bolts. Make your way over a couple of big lumps, clip at 20 feet, and then execute a miserable traverse.
 
-Pitch 2 (10b): 12 bolts.  Step left from the belay, and then launch onto the long, pebbled face with a low and a high crux.  The top of this pitch has the only completely seated belay.  All others are hanging, or partially hanging.
+Pitch 2 (10b): 12 bolts. Step left from the belay, and then launch onto the long, pebbled face with a low and a high crux. The top of this pitch has the only completely seated belay. All others are hanging, or partially hanging.
 
-Pitch 3 (10+/11-): 11 bolts.  Straight above the last pitch, power your way through a series of tough moves on difficult to spot holds in a bulge, and then rejoice on jugs on the face above. Finally, work through one of the easier sections of climbing to the base of the fourth pitch.  Watts gives this 10c, but the crux moves are harder than that.
+Pitch 3 (10+/11-): 11 bolts. Straight above the last pitch, power your way through a series of tough moves on difficult to spot holds in a bulge, and then rejoice on jugs on the face above. Finally, work through one of the easier sections of climbing to the base of the fourth pitch. Watts gives this 10c, but the crux moves are harder than that.
 
 There's another pitch that starts up the left side; ignore it and attack the bulge/overhang.
 
-Pitch 4 (11b): 12 bolts.  The crux pitch, and unfortunately, it isn't the cleanest.  The crux is right off the belay, but it is fairly sustained for another fifty feet.  Take care on the easier upper section - this is one of the dirtier parts of the whole cliff, and more than one hold exploded in my face.
+Pitch 4 (11b): 12 bolts. The crux pitch, and unfortunately, it isn't the cleanest. The crux is right off the belay, but it is fairly sustained for another fifty feet. Take care on the easier upper section - this is one of the dirtier parts of the whole cliff, and more than one hold exploded in my face.
 
 If I remember right, there is also a pitch heading up left from the base of this pitch - take the line on the right.
 
-Pitch 5 (10a): 4 bolts.  A fun traverse on good rock, with a momentarily baffling crux at the end.  Thankfully, the tight bolting makes for a stress-free follow.  Awesome exposure!
+Pitch 5 (10a): 4 bolts. A fun traverse on good rock, with a momentarily baffling crux at the end. Thankfully, the tight bolting makes for a stress-free follow. Awesome exposure!
 
-Pitch 6 (10c): 12 bolts.  Another long pitch of pebbling and edging, this pitch could really use some cleaning.  The belay at the top is heavenly, with amazing views of the main area, monkey face, and beyond.
+Pitch 6 (10c): 12 bolts. Another long pitch of pebbling and edging, this pitch could really use some cleaning. The belay at the top is heavenly, with amazing views of the main area, monkey face, and beyond.
 
 # Location
+
 The route is located on the northeast face of the Smith Rock formation, specifically, the chunk of stone between The Pedestal and the face that contains White Satin and Sky Ridge.
 
-The easiest approach: hike past the main area, to the Pheonix buttress.  At the Pheonix buttress, follow the cliffline back for a few hundred feet.  The route starts vertically, and then on a leftward leaning flake in the center of the face described.
+The easiest approach: hike past the main area, to the Pheonix buttress. At the Pheonix buttress, follow the cliffline back for a few hundred feet. The route starts vertically, and then on a leftward leaning flake in the center of the face described.
 
 There are three routes on the face: a 5.9 start in a groovy sort of thing on the left, this one in the center, and a 10a R that starts in a crack on the right.
 
-Descent: A couple options here.  1) Apparently, you can hike uphill, around the platform and arrowhead, and then scramble down a scree gully, then back to Asterisk Pass.  We couldn't find this way.
+Descent: A couple options here.
 
-2) Make you way downhill (3rd-4th class), back towards Sky Ridge, then look to your left (west) along the ridge for a rap anchor.  This is the descent for "Wherever I May Roam".  The first rappel passes a line of bolts, and then a pair of naked bolts.  Go a little further to a pair of bolts with links, in a little nook in the rock.  The second rappel can drop you to one of two sets of anchors (I am told). The ones on the left, on a small ramp, are 1/2 inch bolts.  My partner tells me there are better bolts, with links, to the right.  One more rappel takes you to the ground.  Hike back to Asterisk Pass.
+1. Apparently, you can hike uphill, around the platform and arrowhead, and then scramble down a scree gully, then back to Asterisk Pass. We couldn't find this way.
+
+2. Make you way downhill (3rd-4th class), back towards Sky Ridge, then look to your left (west) along the ridge for a rap anchor. This is the descent for "Wherever I May Roam". The first rappel passes a line of bolts, and then a pair of naked bolts. Go a little further to a pair of bolts with links, in a little nook in the rock. The second rappel can drop you to one of two sets of anchors (I am told). The ones on the left, on a small ramp, are 1/2 inch bolts. My partner tells me there are better bolts, with links, to the right. One more rappel takes you to the ground. Hike back to Asterisk Pass.
 
 # Protection
-Bolts, and bolted belay anchors.  A couple long slings will reduce rope drag on the occasional zigzag.
+
+Bolts, and bolted belay anchors. A couple long slings will reduce rope drag on the occasional zigzag.
 
 We used 48" slings to equalize anchors, as many are loaded from an angle.

--- a/content/USA/Oregon/Central Oregon/Trout Creek/Main Wall, The/aerie-interlude.md
+++ b/content/USA/Oregon/Central Oregon/Trout Creek/Main Wall, The/aerie-interlude.md
@@ -25,7 +25,7 @@ Black Alien
 
 Blue Alien
 
-#2 Camalot
+# 2 Camalot
 
 Black Alien
 

--- a/content/USA/Oregon/Mt. Hood/Petes Pile/Quirky Combat Wall/qatari-ardah.md
+++ b/content/USA/Oregon/Mt. Hood/Petes Pile/Quirky Combat Wall/qatari-ardah.md
@@ -12,6 +12,7 @@ metadata:
   climb_id: c89d1225-e8ee-4592-829c-e814d7b803b3
   mp_id: ''
 ---
+
 # Description
 
 Sustained thin finger crack sequence followed by a full pitch of glorious hand jams.
@@ -35,6 +36,3 @@ Doubles from Black Totem to C4 #2, singles of C4 #3 and #4, single Metolius #0, 
 ![Pitch #1](https://res.cloudinary.com/openbeta-prod/image/upload/v1637751258/open-tacos/cvr7yepdtwtbmuwqomy0.jpg)
 
 ![Pitch #2](https://res.cloudinary.com/openbeta-prod/image/upload/v1637751484/open-tacos/xwmp21verzemgljodpeo.jpg)
-
-<br>
-

--- a/content/USA/Oregon/Mt. Hood/Petes Pile/Quirky Combat Wall/quadratic-judo.md
+++ b/content/USA/Oregon/Mt. Hood/Petes Pile/Quirky Combat Wall/quadratic-judo.md
@@ -17,7 +17,7 @@ This cracks offers plenty of wide jamming and some decent mandatory offwidth.
 
 Start on the right edge of the mossy platform, straight up to get your first piece, then traverse left to the hand crack.  Keep going straight up passed the roof where the wide climbing starts.  Save everything bigger than #.75 for after the roof.  Long sleeves are helpful.
 
-A 60m will get you down IF the belayer stands on the narrow platform close to the wall.  Tie a stopper knot at the end of the rope. 
+A 60m will get you down IF the belayer stands on the narrow platform close to the wall.  Tie a stopper knot at the end of the rope.
 
 # Location
 Enter the woods by following the trail left of Qatari Ardah. The huge pillar forming a roof should be obvious enough.

--- a/content/USA/Oregon/Mt. Hood/Petes Pile/Quirky Combat Wall/quantum-kung-fu.md
+++ b/content/USA/Oregon/Mt. Hood/Petes Pile/Quirky Combat Wall/quantum-kung-fu.md
@@ -17,7 +17,7 @@ This cracks offers plenty of satisfying jams of all sizes from fingers to fists.
 
 Start on the right edge of the mossy platform, straight up to get your first piece, then traverse left to the hand crack.  Keep going straight up to the roof, traverse right under the roof, pass the bulge, then enjoy the wide climbing.  Long sleeves are helpful.
 
-A 60m will get you down IF the belayer stands on the narrow platform close to the wall.  Tie a stopper knot at the end of the rope. 
+A 60m will get you down IF the belayer stands on the narrow platform close to the wall.  Tie a stopper knot at the end of the rope.
 
 # Location
 Enter the woods by following the trail left of Qatari Ardah. The huge pillar forming a roof should be obvious enough.

--- a/content/USA/Oregon/Mt. Hood/Petes Pile/Quirky Combat Wall/quiet-ninja.md
+++ b/content/USA/Oregon/Mt. Hood/Petes Pile/Quirky Combat Wall/quiet-ninja.md
@@ -24,7 +24,7 @@ p3: 5.10a, 17m, up the v-slot, turn right at the bush, get on top of the column,
 Since p3 is not as good at the first two pitches, you might elect to rap from there.  If you top out after p3, there is another set of rap anchors on the ledge 10 meters right from where you top out that will merge with the route after two raps.  You can rap both options with a single 60m rope.
 
 # Location
-First route on of the Quirky Combat wall. 
+First route on of the Quirky Combat wall.
 
 # Protection
 Doubles to #2, single #3 and #4, triples in thin fingers very useful.

--- a/content/USA/Oregon/Portland  The Gorge/Madrone Wall/Hardscrabble Wall/mountaineer-s-route.md
+++ b/content/USA/Oregon/Portland  The Gorge/Madrone Wall/Hardscrabble Wall/mountaineer-s-route.md
@@ -10,15 +10,17 @@ metadata:
   mp_id: '119816034'
   left_right_index: '11'
 ---
+
 # Description
-Easy climbing over dirty, blocky ledges to the right of Winds of War.  Clip the last bolt of WoW before moving up to the shared anchor.
 
-Fairly unremarkable, but good practice for a new leader, or to set up TR for other climbs on the wall.
-
-*Beware the bush growing out of the rock at the first ledge is poison oak*
+Easy climbing over dirty, blocky ledges to the right of Winds of War.  Clip the last bolt of WoW before moving up to the shared anchor. \
+Fairly unremarkable, but good practice for a new leader, or to set up TR for other climbs on the wall. \
+_Beware the bush growing out of the rock at the first ledge is poison oak_
 
 # Location
+
 Start about 10' to the right of the boltline for Winds of War.
 
 # Protection
+
 Small rack to #3, 1 bolt.

--- a/content/USA/Oregon/Portland  The Gorge/Rocky Butte/Wall of Shadows/pressure-drop.md
+++ b/content/USA/Oregon/Portland  The Gorge/Rocky Butte/Wall of Shadows/pressure-drop.md
@@ -15,7 +15,7 @@ No really, some of the best steep bolted rock in the Portland metro, like Wild T
 
 In keeping with the memorial theme of this wall, this route was put up with Jerry Dellorusso in mind. You were the first climber I ever met, I remember seeing your gear in the closet at college and you talking about this place called the Gunks and driving 95 to get there, and I didn't even know what climbing was back then. I didn't climb until later and we never climbed together, but in your final year you'd started climbing again and we were making plans to finally rope up. You left this place too soon but you left your mark on me and many. Love and miss you, I'm so glad I got to know you.
 
-https://www.youtube.com/watch?v=uw66FA6OTqA
+<https://www.youtube.com/watch?v=uw66FA6OTqA>
 
 # Location
 Start up Chaitanyna (the appealing and left trending ramp), then step out right into the lichen patch at the 30-35 foot mark to reach the first of 5 bolts leading up the left side of an arete and to a bolted anchor.

--- a/content/USA/Oregon/Portland  The Gorge/Rocky Butte/Wall of Shadows/tete-gulley.md
+++ b/content/USA/Oregon/Portland  The Gorge/Rocky Butte/Wall of Shadows/tete-gulley.md
@@ -17,7 +17,7 @@ This route is dedicated to the memory of Tete Gulley, a black trans woman who wa
 
 More information about the murder can be found here:
 
-https://www.portlandmercury.com/blogtown/2019/06/10/26621949/a-black-queer-homeless-portlander-was-found-hanging-from-a-tree-police-say-its-suicide-her-family-disagrees
+<https://www.portlandmercury.com/blogtown/2019/06/10/26621949/a-black-queer-homeless-portlander-was-found-hanging-from-a-tree-police-say-its-suicide-her-family-disagrees>
 
 And as of 2021 there is still a
 

--- a/content/USA/Oregon/Southwest Oregon/Hawaiian Islands/Oahu/dogwood-crack.md
+++ b/content/USA/Oregon/Southwest Oregon/Hawaiian Islands/Oahu/dogwood-crack.md
@@ -13,7 +13,7 @@ metadata:
 # Description
 Project.  Hard start up solid gray chickenheads, slightly overhanging.  Crack starts near top up a mossy ramp and finishes with easy moss to the top.
 
-https://youtu.be/6TYAzKdgX9s
+<https://youtu.be/6TYAzKdgX9s>
 
 # Location
 Obvious gray streak up climber's right starting at bottom of crag.

--- a/content/USA/Oregon/Southwest Oregon/Pilot Rock/north-west-gully.md
+++ b/content/USA/Oregon/Southwest Oregon/Pilot Rock/north-west-gully.md
@@ -14,7 +14,7 @@ metadata:
 # Description
 The obvious North West gulley that the trail dead ends to. BLM Oregon has a complete spray down of the beta
 
-https://www.youtube.com/watch?v=38VZuffSGo0
+<https://www.youtube.com/watch?v=38VZuffSGo0>
 
 Amazing views of Shasta and the surrounding area.
 

--- a/content/USA/Oregon/Southwest Oregon/Shore Acres State Park/Main Cliff/first-ledge-traverse.md
+++ b/content/USA/Oregon/Southwest Oregon/Shore Acres State Park/Main Cliff/first-ledge-traverse.md
@@ -13,7 +13,7 @@ metadata:
 # Description
 Start on an undercling, go to two pockets, and traverse right to the first big ledge you see. Good warm up.
 
-https://www.youtube.com/watch?v=YcD7HSyAnOs
+<https://www.youtube.com/watch?v=YcD7HSyAnOs>
 
 # Location
 North-most end of main cliff.

--- a/content/USA/Oregon/Southwest Oregon/Shore Acres State Park/Main Cliff/zurroball.md
+++ b/content/USA/Oregon/Southwest Oregon/Shore Acres State Park/Main Cliff/zurroball.md
@@ -13,7 +13,7 @@ metadata:
 # Description
 Start on the mushroom jug. Go left on crimps and slopers to the concretion. Give it a bug hug and move up.
 
-https://www.youtube.com/watch?v=oxZOfS9EAbY
+<https://www.youtube.com/watch?v=oxZOfS9EAbY>
 
 # Location
 South side of Main Cliff.

--- a/content/USA/Oregon/index.md
+++ b/content/USA/Oregon/index.md
@@ -6,11 +6,9 @@ metadata:
   lat: 44.5672
   lng: -122.1269
 ---
+
 # Description
 
 # Photos
 
 ![Smith Rock state park (c) Jeff Finley](https://res.cloudinary.com/openbeta-prod/image/upload/v1639562113/open-tacos/nc9dsf6aoitrnehe1cwo.jpg)
-
-<br>
-


### PR DESCRIPTION
Changes to default markdownlint:

# MD012 - Consecutive blank lines
true > false. Changes all files

# MD022 - Blank lines above heading
true > false. Changes all files

# MD013 - line_length: 3000
80 > 3000. Changes all files

# MD025 - Multiple top-level headings in the same document
Current pattern is using all top level headers

# MD043 - Required heading structure
Turned off, wasn't currently consistent enough to enforce anything. 

